### PR TITLE
Filter API key providers and clean preview pages

### DIFF
--- a/preview/index.html
+++ b/preview/index.html
@@ -19,19 +19,19 @@
 		body, #container { height: 100%; margin: 0; padding: 0;}
 		.map { height: 100%; }
 
-		#info {
-			background: rgba(255, 255, 255, 0.85);
-			box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
-			position: fixed;
-			width: 50%;
-			max-width: 600px;
-			left: 45%;
-			margin-left: -300px;
-			padding: 6px 8px;
+               #info {
+                       background: rgba(255, 255, 255, 0.85);
+                       box-shadow: 0 0 15px rgba(0, 0, 0, 0.2);
+                       position: fixed;
+                       left: 0;
+                       right: 0;
+                       top: 0;
+                       padding: 6px 8px;
 
-			border-radius: 5px;
-			font: 14px/16px Arial, Helvetica, sans-serif;
-		}
+                       border-radius: 0 0 5px 5px;
+                       font: 14px/16px Arial, Helvetica, sans-serif;
+                       z-index: 1000;
+               }
 		#info h4:first-child {
 			margin: 0 0 5px;
 		}
@@ -54,20 +54,10 @@
 			overflow-x: auto;
 		}
 	</style>
-	<!--Fork Me on Github ribbon, we're using the awesome version from simonwhitaker available at https://github.com/simonwhitaker/github-fork-ribbon-css  -->
-	<link rel="stylesheet" href="../css/gh-fork-ribbon.css" />
-	<!--[if IE]>
-		<link rel="stylesheet" href="../css/gh-fork-ribbon.ie.css" />
-	<![endif]-->
 	<link rel="stylesheet" href="vendor/github.css">
 	<link rel="stylesheet" href="vendor/control.layers.minimap.css">
 </head>
 <body>
-	<div class="github-fork-ribbon-wrapper left">
-		<div class="github-fork-ribbon">
-			<a href="https://github.com/leaflet-extras/leaflet-providers">Fork me on GitHub</a>
-		</div>
-	</div>
 
 	<div id="info">
 		<h4><a href="https://github.com/leaflet-extras/leaflet-providers">Leaflet-providers preview</a></h4>

--- a/preview/preview.js
+++ b/preview/preview.js
@@ -92,12 +92,35 @@
 		return false;
 	};
 
+	var requiresApiKey = function(providerName) {
+		var parts = providerName.split('.');
+		var provider = L.TileLayer.Provider.providers[parts[0]];
+		if (!provider) {
+			return false;
+		}
+		var options = L.extend({}, provider.options);
+		if (parts.length > 1 && provider.variants && provider.variants[parts[1]]) {
+			var variant = provider.variants[parts[1]];
+			if (typeof variant === 'string') {
+				options.variant = variant;
+			} else if (variant.options) {
+				options = L.extend(options, variant.options);
+			}
+		}
+		for (var key in options) {
+			if (typeof options[key] === 'string' && (/<insert[^>]*here>/i).test(options[key])) {
+				return true;
+			}
+		}
+		return false;
+	};
+
 	// collect all layers available in the provider definition
 	var baseLayers = {};
 	var overlays = {};
 
 	var addLayer = function(name) {
-		if (isIgnored(name)) {
+		if (isIgnored(name) || requiresApiKey(name)) {
 			return;
 		}
 		var layer = L.tileLayer.provider(name);

--- a/preview/test-bounds.html
+++ b/preview/test-bounds.html
@@ -44,18 +44,8 @@
 		}
 
 	</style>
-	<!--Fork Me on Github ribbon, we're using the awesome version from simonwhitaker available at https://github.com/simonwhitaker/github-fork-ribbon-css  -->
-	<link rel="stylesheet" href="../css/gh-fork-ribbon.css" />
-	<!--[if IE]>
-		<link rel="stylesheet" href="../css/gh-fork-ribbon.ie.css" />
-	<![endif]-->
 </head>
 <body>
-	<div class="github-fork-ribbon-wrapper right">
-		<div class="github-fork-ribbon">
-			<a href="https://github.com/leaflet-extras/leaflet-providers">Fork me on GitHub</a>
-		</div>
-	</div>
 
 	<div class="sidebar">
 		<h1>Testing provider bounds</h1>

--- a/preview/test-https-support.html
+++ b/preview/test-https-support.html
@@ -41,18 +41,8 @@
 			color: green;
 		}
 	</style>
-	<!--Fork Me on Github ribbon, we're using the awesome version from simonwhitaker available at https://github.com/simonwhitaker/github-fork-ribbon-css  -->
-	<link rel="stylesheet" href="../css/gh-fork-ribbon.css" />
-	<!--[if IE]>
-		<link rel="stylesheet" href="../css/gh-fork-ribbon.ie.css" />
-	<![endif]-->
 </head>
 <body>
-	<div class="github-fork-ribbon-wrapper right">
-		<div class="github-fork-ribbon">
-			<a href="https://github.com/leaflet-extras/leaflet-providers">Fork me on GitHub</a>
-		</div>
-	</div>
 
 	<h1>Testing provider protocols</h1>
 	<div class="container">


### PR DESCRIPTION
## Summary
- remove "Fork me" ribbon from preview pages
- show demo code panel at the top of preview
- hide providers that require an API key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_684ca185e09883279d10527cc2992972