### PR TITLE
Add UI tools to code generator

### DIFF
--- a/preview/code-generator.html
+++ b/preview/code-generator.html
@@ -35,6 +35,8 @@
                 }
         </style>
         <link rel="stylesheet" href="vendor/github.css" />
+        <link rel="stylesheet" href="vendor/leaflet.draw.css" />
+        <link rel="stylesheet" href="https://unpkg.com/leaflet-minimap@3.6.1/dist/Control.MiniMap.min.css" />
 </head>
 <body>
         <div id="map" class="map"></div>
@@ -45,12 +47,20 @@
                         <summary>Overlays</summary>
                         <ul id="overlay-list"></ul>
                 </details>
+                <details open>
+                        <summary>Tools</summary>
+                        <label><input type="checkbox" id="toggle-scale" checked> Scale Bar</label><br>
+                        <label><input type="checkbox" id="toggle-minimap"> Mini Map</label><br>
+                        <label><input type="checkbox" id="toggle-draw"> Drawing</label>
+                </details>
         </div>
         <pre id="code"><code class="javascript" id="code-output"></code></pre>
 
        <script src="vendor/leaflet.js"></script>
         <script src="../leaflet-providers.js"></script>
         <script src="vendor/highlight.pack.js"></script>
+        <script src="vendor/leaflet.draw-src.js"></script>
+        <script src="https://unpkg.com/leaflet-minimap@3.6.1/dist/Control.MiniMap.min.js"></script>
         <script src="shared.js"></script>
         <script src="code-generator.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- enable Leaflet draw and MiniMap plugins in the code generator
- add checkboxes for scale bar, mini map and drawing tools
- output generated code for the chosen tools

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68546e73ac508327887f7d9911bd7158